### PR TITLE
Component Refactor Overhaul: Part 1 (Cleanup)

### DIFF
--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -9,67 +9,18 @@ import {
   MenuItem,
   Select,
   Typography,
-  createStyles,
+  Container,
+  Grid,
 } from '@material-ui/core';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 
 import { callDalleService } from 'api/backend_api';
 import BackendUrlInput from 'components/BackendUrlInput';
 import GeneratedImageList from 'components/GeneratedImageList';
+import Header from 'components/Header';
 import LoadingSpinner from 'components/LoadingSpinner';
 import TextPromptInput from 'components/TextPromptInput';
 
-const useStyles = () =>
-  createStyles({
-    root: {
-      display: 'flex',
-      width: '100%',
-      flexDirection: 'column',
-      margin: '60px 0px 60px 0px',
-      alignItems: 'center',
-      textAlign: 'center',
-    },
-    title: {
-      marginBottom: '20px',
-    },
-    playgroundSection: {
-      display: 'flex',
-      flex: 1,
-      width: '100%',
-      alignItems: 'flex-start',
-      justifyContent: 'center',
-      marginTop: '20px',
-    },
-    settingsSection: {
-      display: 'flex',
-      flexDirection: 'column',
-      padding: '1em',
-      maxWidth: '300px',
-    },
-    searchQueryCard: {
-      marginBottom: '20px',
-    },
-    imagesPerQueryControl: {
-      marginTop: '20px',
-    },
-    formControl: {
-      margin: '20px',
-      minWidth: 120,
-    },
-    gallery: {
-      display: 'flex',
-      flex: '1',
-      maxWidth: '50%',
-      height: '100%',
-      justifyContent: 'center',
-      alignItems: 'flex-start',
-      padding: '1rem',
-    },
-  });
-
-type Props = WithStyles<typeof useStyles>;
-
-const App: FC<Props> = ({ classes }) => {
+const App: FC = () => {
   const [backendUrl, setBackendUrl] = useState('');
   const [isFetchingImgs, setIsFetchingImgs] = useState(false);
   const [isCheckingBackendEndpoint, setIsCheckingBackendEndpoint] = useState(false);
@@ -124,27 +75,21 @@ const App: FC<Props> = ({ classes }) => {
   }
 
   return (
-    <div className={classes.root}>
-      <div className={classes.title}>
-        <Typography variant="h3">
-          DALL-E Playground{' '}
-          <span role="img" aria-label="sparks-emoji">
-            ✨
-          </span>
-        </Typography>
-      </div>
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Header />
+        </Grid>
+        {!validBackendUrl && (
+          <Grid item xs={12}>
+            <Typography variant="body1" color="textSecondary">
+              Put your DALL-E backend URL to start
+            </Typography>
+          </Grid>
+        )}
 
-      {!validBackendUrl && (
-        <div>
-          <Typography variant="body1" color="textSecondary">
-            Put your DALL-E backend URL to start
-          </Typography>
-        </div>
-      )}
-
-      <div className={classes.playgroundSection}>
-        <div className={classes.settingsSection}>
-          <Card className={classes.searchQueryCard}>
+        <Grid item xs={4}>
+          <Card>
             <CardContent>
               <BackendUrlInput
                 setBackendValidUrl={setBackendUrl}
@@ -159,7 +104,7 @@ const App: FC<Props> = ({ classes }) => {
                 disabled={isFetchingImgs || !validBackendUrl}
               />
 
-              <FormControl className={classes.imagesPerQueryControl} variant="outlined">
+              <FormControl variant="outlined">
                 <InputLabel id="images-per-query-label">Images to generate</InputLabel>
                 <Select
                   labelId="images-per-query-label"
@@ -185,13 +130,17 @@ const App: FC<Props> = ({ classes }) => {
               Query execution time: {queryTime} sec
             </Typography>
           )}
-        </div>
-        {(generatedImages.length > 0 || apiError || isFetchingImgs) && (
-          <div className={classes.gallery}>{getGalleryContent()}</div>
-        )}
-      </div>
-    </div>
+        </Grid>
+        <Grid item xs={8}>
+          {(generatedImages.length > 0 || apiError || isFetchingImgs) && (
+            <div>{getGalleryContent()}</div>
+          )}
+        </Grid>
+      </Grid>
+    </Container>
   );
 };
 
-export default withStyles(useStyles)(App);
+App.displayName = 'App';
+
+export default App;

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -11,6 +11,8 @@ import {
   Typography,
   Container,
   Grid,
+  CardActions,
+  Button,
 } from '@material-ui/core';
 
 import { callDalleService } from 'api/backend_api';
@@ -107,6 +109,11 @@ const App: FC = () => {
                 </Select>
                 <FormHelperText>More images = slower query</FormHelperText>
               </FormControl>
+              <CardActions>
+                <Button variant="contained" color="primary" fullWidth>
+                  Submit
+                </Button>
+              </CardActions>
             </CardContent>
           </Card>
           {queryTime !== 0 && (

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -89,7 +89,6 @@ const App: FC = () => {
                 enterPressedCallback={enterPressedCallback}
                 disabled={isFetchingImgs || !validBackendUrl}
               />
-
               <FormControl variant="outlined">
                 <InputLabel id="images-per-query-label">Images to generate</InputLabel>
                 <Select

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -58,22 +58,6 @@ const App: FC = () => {
       });
   }
 
-  function getGalleryContent() {
-    if (apiError) {
-      return (
-        <Typography variant="h5" color="error">
-          {apiError}
-        </Typography>
-      );
-    }
-
-    if (isFetchingImgs) {
-      return <LoadingSpinner isLoading={isFetchingImgs} />;
-    }
-
-    return <GeneratedImageList generatedImages={generatedImages} />;
-  }
-
   return (
     <Container>
       <Grid container spacing={2}>
@@ -133,7 +117,15 @@ const App: FC = () => {
         </Grid>
         <Grid item xs={8}>
           {(generatedImages.length > 0 || apiError || isFetchingImgs) && (
-            <div>{getGalleryContent()}</div>
+            <>
+              {!!apiError && (
+                <Typography variant="h5" color="error">
+                  {apiError}
+                </Typography>
+              )}
+              {isFetchingImgs && <LoadingSpinner searchTerm={''} isLoading={isFetchingImgs} />}
+              {generatedImages && <GeneratedImageList generatedImages={generatedImages} />}
+            </>
           )}
         </Grid>
       </Grid>

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -116,17 +116,13 @@ const App: FC = () => {
           )}
         </Grid>
         <Grid item xs={8}>
-          {(generatedImages.length > 0 || apiError || isFetchingImgs) && (
-            <>
-              {!!apiError && (
-                <Typography variant="h5" color="error">
-                  {apiError}
-                </Typography>
-              )}
-              {isFetchingImgs && <LoadingSpinner searchTerm={''} isLoading={isFetchingImgs} />}
-              {generatedImages && <GeneratedImageList generatedImages={generatedImages} />}
-            </>
+          {!!apiError && (
+            <Typography variant="h5" color="error">
+              {apiError}
+            </Typography>
           )}
+          {isFetchingImgs && <LoadingSpinner searchTerm={''} isLoading={isFetchingImgs} />}
+          {generatedImages.length > 0 && <GeneratedImageList generatedImages={generatedImages} />}
         </Grid>
       </Grid>
     </Container>

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -3,11 +3,6 @@ import React, { FC, useState } from 'react';
 import {
   Card,
   CardContent,
-  FormControl,
-  FormHelperText,
-  InputLabel,
-  MenuItem,
-  Select,
   Typography,
   Container,
   Grid,
@@ -19,20 +14,19 @@ import { callDalleService } from 'api/backend_api';
 import BackendUrlInput from 'components/BackendUrlInput';
 import GeneratedImageList from 'components/GeneratedImageList';
 import Header from 'components/Header';
+import ImagesPerQuerySelect from 'components/ImagesPerQuerySelect';
 import LoadingSpinner from 'components/LoadingSpinner';
 import TextPromptInput from 'components/TextPromptInput';
 
 const App: FC = () => {
-  const [backendUrl, setBackendUrl] = useState('');
+  const [backendUrl] = useState('');
   const [isFetchingImgs, setIsFetchingImgs] = useState(false);
-  const [isCheckingBackendEndpoint, setIsCheckingBackendEndpoint] = useState(false);
-  const [isValidBackendEndpoint, setIsValidBackendEndpoint] = useState(true);
+  const [isValidBackendEndpoint] = useState(true);
   const [generatedImages, setGeneratedImages] = useState([]);
   const [apiError, setApiError] = useState('');
-  const [imagesPerQuery, setImagesPerQuery] = useState(2);
+  const [imagesPerQuery] = useState(2);
   const [queryTime, setQueryTime] = useState(0);
 
-  const imagesPerQueryOptions = 10;
   const validBackendUrl = isValidBackendEndpoint && backendUrl;
 
   function enterPressedCallback(promptText: string) {
@@ -77,37 +71,12 @@ const App: FC = () => {
         <Grid item xs={4}>
           <Card>
             <CardContent>
-              <BackendUrlInput
-                setBackendValidUrl={setBackendUrl}
-                isValidBackendEndpoint={isValidBackendEndpoint}
-                setIsValidBackendEndpoint={setIsValidBackendEndpoint}
-                setIsCheckingBackendEndpoint={setIsCheckingBackendEndpoint}
-                isCheckingBackendEndpoint={isCheckingBackendEndpoint}
-                disabled={isFetchingImgs}
-              />
+              <BackendUrlInput isDisabled={isFetchingImgs} />
               <TextPromptInput
                 enterPressedCallback={enterPressedCallback}
                 disabled={isFetchingImgs || !validBackendUrl}
               />
-              <FormControl variant="outlined">
-                <InputLabel id="images-per-query-label">Images to generate</InputLabel>
-                <Select
-                  labelId="images-per-query-label"
-                  label="Images per query"
-                  value={imagesPerQuery}
-                  disabled={isFetchingImgs}
-                  onChange={(event) => setImagesPerQuery(parseInt(event.target.value as string))}
-                >
-                  {Array.from(Array(imagesPerQueryOptions).keys()).map((num) => {
-                    return (
-                      <MenuItem key={num + 1} value={num + 1}>
-                        {num + 1}
-                      </MenuItem>
-                    );
-                  })}
-                </Select>
-                <FormHelperText>More images = slower query</FormHelperText>
-              </FormControl>
+              <ImagesPerQuerySelect isDisabled={isFetchingImgs} />
               <CardActions>
                 <Button variant="contained" color="primary" fullWidth>
                   Submit

--- a/interface/src/api/backend_api.js
+++ b/interface/src/api/backend_api.js
@@ -33,17 +33,10 @@ export async function callDalleService(backendUrl, text, numImages) {
   };
 }
 
-export async function checkIfValidBackend(backendUrl) {
-  return await fetch(backendUrl, {
+export const validateDalleServer = (backendUrl) =>
+  fetch(backendUrl, {
     headers: {
       'Bypass-Tunnel-Reminder': 'go',
       mode: 'no-cors',
     },
-  })
-    .then(() => {
-      return true;
-    })
-    .catch(() => {
-      return false;
-    });
-}
+  });

--- a/interface/src/components/Header.tsx
+++ b/interface/src/components/Header.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react';
+
+import { Typography } from '@material-ui/core';
+
+const Header: FC = () => {
+  return (
+    <Typography variant="h3" color="textPrimary" component="h1">
+      DALL-E Playground
+    </Typography>
+  );
+};
+
+Header.displayName = 'Header';
+
+export default Header;

--- a/interface/src/components/ImagesPerQuerySelect.tsx
+++ b/interface/src/components/ImagesPerQuerySelect.tsx
@@ -1,0 +1,48 @@
+import React, { FC, useCallback, useContext } from 'react';
+
+import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@material-ui/core';
+
+import { FormContext } from 'contexts/FormContext';
+
+import { DEFAULT_MAX_IMAGES_PER_QUERY_OPTIONS } from '../utils.js';
+
+type Props = {
+  isDisabled: boolean;
+};
+
+const ImagesPerQuerySelect: FC<Props> = ({ isDisabled }) => {
+  const { imagesPerQuery, setImagesPerQuery } = useContext(FormContext);
+
+  const options = Array.from(Array(DEFAULT_MAX_IMAGES_PER_QUERY_OPTIONS).keys());
+
+  const handleOnChange = useCallback(
+    (newQueryLimit: string) => setImagesPerQuery(parseInt(newQueryLimit)),
+    [setImagesPerQuery],
+  );
+
+  return (
+    <FormControl fullWidth>
+      <InputLabel id="images-per-query-label">Images to generate</InputLabel>
+      <Select
+        labelId="images-per-query-label"
+        label="Images per query"
+        value={imagesPerQuery}
+        onChange={(evt) => handleOnChange(evt.target.value as string)}
+        disabled={isDisabled}
+      >
+        {options.map((num) => {
+          return (
+            <MenuItem key={num + 1} value={num + 1}>
+              {num + 1}
+            </MenuItem>
+          );
+        })}
+      </Select>
+      <FormHelperText>More images = slower query</FormHelperText>
+    </FormControl>
+  );
+};
+
+ImagesPerQuerySelect.displayName = 'ImagesPerQuerySelect';
+
+export default ImagesPerQuerySelect;

--- a/interface/src/components/LoadingSpinner.tsx
+++ b/interface/src/components/LoadingSpinner.tsx
@@ -21,9 +21,10 @@ const processingSteps = ['Generating images 👨🏽‍🎨', 'Doing fancy calcu
 
 interface Props extends WithStyles<typeof useStyles> {
   isLoading: boolean;
+  searchTerm: string;
 }
 
-const LoadingSpinner: FC<Props> = ({ classes, isLoading }) => {
+const LoadingSpinner: FC<Props> = ({ classes, isLoading, searchTerm }) => {
   const [textIdx, setTextIdx] = useState(0);
 
   useEffect(() => {
@@ -43,6 +44,7 @@ const LoadingSpinner: FC<Props> = ({ classes, isLoading }) => {
   return (
     <div className={classes.root}>
       <PulseLoader size={20} loading={isLoading} />
+      {searchTerm}
       <Typography className={classes.loadingText} variant={'h6'}>
         {loadingText}
       </Typography>

--- a/interface/src/contexts/FormContext.tsx
+++ b/interface/src/contexts/FormContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, FC, useState } from 'react';
+
+import { DEFAULT_BACKEND_URL, DEFAULT_QUERY_STRING, DEFAULT_IMAGES_PER_QUERY } from 'utils';
+
+type ProviderProps = {
+  backendURL: string;
+  setBackendURL: (url: string) => void;
+  queryString: string;
+  setQueryString: (url: string) => void;
+  isValidURL: boolean;
+  setIsValidURL: (isValid: boolean) => void;
+  validatedBackendURL: boolean | string;
+  imagesPerQuery: number;
+  setImagesPerQuery: (limit: number) => void;
+};
+
+// Create context
+const FormContext = createContext<ProviderProps>({} as ProviderProps);
+FormContext.displayName = 'FormContext';
+
+const FormContextProvider: FC<{
+  children?: JSX.Element;
+}> = ({ children }) => {
+  const [backendURL, setBackendURL] = useState<string>(DEFAULT_BACKEND_URL);
+  const [imagesPerQuery, setImagesPerQuery] = useState(DEFAULT_IMAGES_PER_QUERY);
+  const [queryString, setQueryString] = useState<string>(DEFAULT_QUERY_STRING);
+
+  const [isValidURL, setIsValidURL] = useState(false);
+
+  const value = {
+    queryString,
+    setQueryString,
+    backendURL,
+    setBackendURL,
+    isValidURL,
+    setIsValidURL,
+    validatedBackendURL: isValidURL && backendURL,
+    imagesPerQuery,
+    setImagesPerQuery,
+  };
+
+  return <FormContext.Provider value={value}>{children}</FormContext.Provider>;
+};
+
+FormContextProvider.displayName = 'FormContextProvider';
+
+export { FormContextProvider, FormContext };

--- a/interface/src/index.tsx
+++ b/interface/src/index.tsx
@@ -1,16 +1,24 @@
 import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import ReactDOM from 'react-dom/client';
 
 import App from 'App';
 
+import { FormContextProvider } from './contexts/FormContext';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
+const queryClient = new QueryClient();
+
 root.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <FormContextProvider>
+        <App />
+      </FormContextProvider>
+    </QueryClientProvider>
   </React.StrictMode>,
 );
 

--- a/interface/src/utils.js
+++ b/interface/src/utils.js
@@ -1,4 +1,4 @@
-export const isValidURL = (str) => {
+export const validateURL = (str) => {
   const pattern = new RegExp(
     '^(https?:\\/\\/)?' + // protocol
       '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name

--- a/interface/src/utils.js
+++ b/interface/src/utils.js
@@ -1,4 +1,4 @@
-export function isValidURL(str) {
+export const isValidURL = (str) => {
   const pattern = new RegExp(
     '^(https?:\\/\\/)?' + // protocol
       '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
@@ -10,4 +10,21 @@ export function isValidURL(str) {
   ); // fragment locator
 
   return Boolean(pattern.test(str));
-}
+};
+
+export const DEFAULT_BACKEND_URL = 'http://127.0.0.1:8080';
+
+export const DEFAULT_IMAGES_PER_QUERY = 1;
+
+export const DEFAULT_MAX_IMAGES_PER_QUERY_OPTIONS = 9;
+
+export const DEFAULT_QUERY_STRING = 'Apple';
+
+export const PROCESSING_STEPS = [
+  'Generating images',
+  'This requires some fancy calculations',
+  'Still processing',
+  "We promise it's worth the wait",
+  "Hang tight, we're almost there",
+  'Loading results, we swear!',
+];


### PR DESCRIPTION
This is an effort to modernize, clean up, and simplify some of the components and patterns in the Interface application for later improvements.

This is a multi-part effort. Within this PR, the following is performed:

- Create a Form Context & Provider
- Use a strict grid system on App
- Componentize the Image Quantity selector
- Create a submit button, for later usage with React-Query
- Simplify the logic for the gallery - will be abstracted to their own components later
- Typing
- Removal of magic strings